### PR TITLE
iter, parallel: Improve some more generics decls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
+
+retract v2.0.0

--- a/iter/accum.go
+++ b/iter/accum.go
@@ -27,7 +27,7 @@ func Accum[F ~func(T, T) T, T any](inp Of[T], f F) Of[T] {
 // and
 //
 //	out[i+1] == f(out[i], inp[i+1])
-func Accumx[F func(T, T) (T, error), T any](inp Of[T], f F) Of[T] {
+func Accumx[F ~func(T, T) (T, error), T any](inp Of[T], f F) Of[T] {
 	return &accumIter[T]{
 		inp:   inp,
 		f:     f,

--- a/iter/accum.go
+++ b/iter/accum.go
@@ -10,7 +10,7 @@ package iter
 // and
 //
 //	out[i+1] == f(out[i], inp[i+1])
-func Accum[T any](inp Of[T], f func(T, T) T) Of[T] {
+func Accum[F ~func(T, T) T, T any](inp Of[T], f F) Of[T] {
 	return Accumx(inp, func(a, b T) (T, error) {
 		return f(a, b), nil
 	})
@@ -27,7 +27,7 @@ func Accum[T any](inp Of[T], f func(T, T) T) Of[T] {
 // and
 //
 //	out[i+1] == f(out[i], inp[i+1])
-func Accumx[T any](inp Of[T], f func(T, T) (T, error)) Of[T] {
+func Accumx[F func(T, T) (T, error), T any](inp Of[T], f F) Of[T] {
 	return &accumIter[T]{
 		inp:   inp,
 		f:     f,

--- a/iter/chan.go
+++ b/iter/chan.go
@@ -135,7 +135,7 @@ func toChan[T any](ctx context.Context, inp Of[T]) (<-chan T, func() error) {
 // The function receives a channel for producing values.
 // The channel closes when the function exits.
 // Any error produced by the function is the value of the iterator's Err method.
-func Go[T any](f func(ch chan<- T) error) Of[T] {
+func Go[F func(chan<- T) error, T any](f F) Of[T] {
 	var (
 		ch  = make(chan T)
 		res = &chanIter[T]{ch: ch}

--- a/iter/chan.go
+++ b/iter/chan.go
@@ -135,7 +135,7 @@ func toChan[T any](ctx context.Context, inp Of[T]) (<-chan T, func() error) {
 // The function receives a channel for producing values.
 // The channel closes when the function exits.
 // Any error produced by the function is the value of the iterator's Err method.
-func Go[F func(chan<- T) error, T any](f F) Of[T] {
+func Go[F ~func(chan<- T) error, T any](f F) Of[T] {
 	var (
 		ch  = make(chan T)
 		res = &chanIter[T]{ch: ch}

--- a/iter/filter.go
+++ b/iter/filter.go
@@ -2,7 +2,7 @@ package iter
 
 // Filter copies the input iterator to the output,
 // including only those elements that cause f to return true.
-func Filter[T any](inp Of[T], f func(T) bool) Of[T] {
+func Filter[F ~func(T) bool, T any](inp Of[T], f F) Of[T] {
 	return &filterIter[T]{inp: inp, f: f}
 }
 
@@ -34,7 +34,7 @@ func (f *filterIter[T]) Err() error {
 // discarding the initial elements until the first one that causes f to return true.
 // That element and the remaining elements of inp are included in the output,
 // and f is not called again.
-func SkipUntil[T any](inp Of[T], f func(T) bool) Of[T] {
+func SkipUntil[F ~func(T) bool, T any](inp Of[T], f F) Of[T] {
 	skipping := true
 	return Filter(inp, func(val T) bool {
 		if !skipping {

--- a/iter/gen.go
+++ b/iter/gen.go
@@ -10,7 +10,7 @@ import (
 // iteration stops and the error is available via the iterator's Err method.
 // Otherwise, each call to f should return a value and a true boolean.
 // When f returns a false boolean, it signals the normal end of iteration.
-func Gen[T any](f func() (T, bool, error)) Of[T] {
+func Gen[F ~func() (T, bool, error), T any](f F) Of[T] {
 	return &genIter[T]{f: f}
 }
 

--- a/iter/gomap.go
+++ b/iter/gomap.go
@@ -24,7 +24,7 @@ func (*goMapIter[K, V]) Err() error {
 }
 
 // FromMap produces an iterator of key-value pairs from a Go map.
-func FromMap[K comparable, V any](m map[K]V) Of[Pair[K, V]] {
+func FromMap[M ~map[K]V, K comparable, V any](m M) Of[Pair[K, V]] {
 	return &goMapIter[K, V]{
 		m:        m,
 		keysIter: FromMapKeys(m),
@@ -32,7 +32,7 @@ func FromMap[K comparable, V any](m map[K]V) Of[Pair[K, V]] {
 }
 
 // FromMapKeys produces an iterator over the keys of a Go map.
-func FromMapKeys[K comparable, V any](m map[K]V) Of[K] {
+func FromMapKeys[M ~map[K]V, K comparable, V any](m M) Of[K] {
 	keys := make([]K, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/iter/map.go
+++ b/iter/map.go
@@ -1,7 +1,7 @@
 package iter
 
 // Map produces an iterator of values transformed from an input iterator by a simple mapping function.
-func Map[T, U any](inp Of[T], f func(T) U) Of[U] {
+func Map[F ~func(T) U, T, U any](inp Of[T], f F) Of[U] {
 	return Mapx(inp, func(val T) (U, error) {
 		return f(val), nil
 	})
@@ -11,7 +11,7 @@ func Map[T, U any](inp Of[T], f func(T) U) Of[U] {
 // It produces an iterator of values transformed from an input iterator by a mapping function.
 // If the mapping function returns an error,
 // iteration stops and the error is available via the output iterator's Err method.
-func Mapx[T, U any](inp Of[T], f func(T) (U, error)) Of[U] {
+func Mapx[F func(T) (U, error), T, U any](inp Of[T], f F) Of[U] {
 	return &mapIter[T, U]{inp: inp, f: f}
 }
 

--- a/iter/map.go
+++ b/iter/map.go
@@ -11,7 +11,7 @@ func Map[F ~func(T) U, T, U any](inp Of[T], f F) Of[U] {
 // It produces an iterator of values transformed from an input iterator by a mapping function.
 // If the mapping function returns an error,
 // iteration stops and the error is available via the output iterator's Err method.
-func Mapx[F func(T) (U, error), T, U any](inp Of[T], f F) Of[U] {
+func Mapx[F ~func(T) (U, error), T, U any](inp Of[T], f F) Of[U] {
 	return &mapIter[T, U]{inp: inp, f: f}
 }
 

--- a/iter/page.go
+++ b/iter/page.go
@@ -11,7 +11,7 @@ package iter
 //
 // The slice in every non-final call of the callback is guaranteed to have a length of pageSize.
 // The final call of the callback may contain an empty slice.
-func Page[F func(S, bool) error, S ~[]T, T any](inp Of[T], pageSize int, f F) error {
+func Page[F ~func(S, bool) error, S ~[]T, T any](inp Of[T], pageSize int, f F) error {
 	page := make([]T, 0, pageSize)
 	for inp.Next() {
 		page = append(page, inp.Val())

--- a/iter/page.go
+++ b/iter/page.go
@@ -11,7 +11,7 @@ package iter
 //
 // The slice in every non-final call of the callback is guaranteed to have a length of pageSize.
 // The final call of the callback may contain an empty slice.
-func Page[T any](inp Of[T], pageSize int, f func([]T, bool) error) error {
+func Page[F func(S, bool) error, S ~[]T, T any](inp Of[T], pageSize int, f F) error {
 	page := make([]T, 0, pageSize)
 	for inp.Next() {
 		page = append(page, inp.Val())


### PR DESCRIPTION
In v2.0.0 we improved the generics decls for functions in `slices` and `maps` to bring them in line with the upcoming stdlib changes. But there were opportunities to do the same in `iter` and `parallel`, which this PR does.

Technically it's a major change to the API that should warrant a v3 release. But since v2 has been out for only a couple of hours I'm cutting a corner, calling this v2.1.0, and retracting v2.0.0.