### PR TITLE
Add iter.FromSeq{,2}{,Context}

### DIFF
--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -82,3 +82,23 @@ func TestFromSeq(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+
+func TestFromSeq2(t *testing.T) {
+	names := []string{"Alice", "Bob", "Carol"}
+	seq2 := func(yield func(int, string) bool) {
+		for i, name := range names {
+			if !yield(i, name) {
+				break
+			}
+		}
+	}
+	it := FromSeq2(seq2)
+	got, err := ToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Pair[int, string]{{0, "Alice"}, {1, "Bob"}, {2, "Carol"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -137,3 +137,37 @@ func TestFromSeqContext(t *testing.T) {
 		t.Errorf("got %v, want []", got)
 	}
 }
+
+func TestFromSeq2Context(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	names := []string{"Alice", "Bob", "Carol"}
+	seq2 := func(yield func(int, string) bool) {
+		for i, name := range names {
+			if !yield(i, name) {
+				break
+			}
+		}
+	}
+
+	it := FromSeq2Context(ctx, seq2)
+
+	if !it.Next() {
+		t.Fatal("it.Next() returned false, want true")
+	}
+	val0 := it.Val()
+	if val0.X != 0 || val0.Y != "Alice" {
+		t.Errorf("got %v, want {0, Alice}", val0)
+	}
+
+	cancel()
+
+	got, err := ToSlice(it)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want %v", err, context.Canceled)
+	}
+	if len(got) > 0 {
+		t.Errorf("got %v, want []", got)
+	}
+}

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -63,3 +63,22 @@ func testSeq2[T, U any](t *testing.T, seq Seq2[T, U], wantT []T, wantU []U) {
 		t.Errorf("got %v, want %v", gotU, wantU)
 	}
 }
+
+func TestFromSeq(t *testing.T) {
+	seq := func(yield func(int) bool) {
+		for i := 0; i < 5; i++ {
+			if !yield(i) {
+				break
+			}
+		}
+	}
+	it := FromSeq(seq)
+	got, err := ToSlice(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []int{0, 1, 2, 3, 4}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Add adapters for converting Go 1.23 iterators to `iter.Of`s.