### PR TITLE
Upgrade modver to v2.9.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Modver
         if: ${{ github.event_name == 'pull_request' }}
-        uses: bobg/modver@v2.7.0
+        uses: bobg/modver@v2.9.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}


### PR DESCRIPTION
This PR upgrades Modver to v2.9.0, needed in order to properly check PRs (such as #18) originating from forked copies of the repository. See https://github.com/bobg/modver/releases/tag/v2.8.0.