### PR TITLE
Remove ~func type params in parallel package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.23
 
 require golang.org/x/sync v0.8.0
 
-require github.com/bobg/seqs v1.0.0
+require github.com/bobg/seqs v1.2.0
 
 require github.com/bobg/go-generics/v3 v3.7.0 // indirect
+
+retract v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bobg/go-generics/v3 v3.7.0 h1:4SJHDWqONTRcA8al6491VW/ys6061bPCcTcI7Yn
 github.com/bobg/go-generics/v3 v3.7.0/go.mod h1:wGlMLQER92clsh3cJoQjbUtUEJ03FoxnGhZjaWhf4fM=
 github.com/bobg/seqs v1.0.0 h1:BcBwTAMX9DKkKPx6Q7+uiZwuMw2/Pj3c2HZA9nJBPag=
 github.com/bobg/seqs v1.0.0/go.mod h1:icgB+vXIoU6s675tLYVAgcUYry1PkYwgEKvzOuFemOk=
+github.com/bobg/seqs v1.2.0 h1:y9SS1zisfkNQepd+xia/3ELDYR4T4vuLTyCA4UVOiKA=
+github.com/bobg/seqs v1.2.0/go.mod h1:icgB+vXIoU6s675tLYVAgcUYry1PkYwgEKvzOuFemOk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/bobg/go-generics/v3 v3.7.0 h1:4SJHDWqONTRcA8al6491VW/ys6061bPCcTcI7YnIHPc=
 github.com/bobg/go-generics/v3 v3.7.0/go.mod h1:wGlMLQER92clsh3cJoQjbUtUEJ03FoxnGhZjaWhf4fM=
-github.com/bobg/seqs v1.0.0 h1:BcBwTAMX9DKkKPx6Q7+uiZwuMw2/Pj3c2HZA9nJBPag=
-github.com/bobg/seqs v1.0.0/go.mod h1:icgB+vXIoU6s675tLYVAgcUYry1PkYwgEKvzOuFemOk=
 github.com/bobg/seqs v1.2.0 h1:y9SS1zisfkNQepd+xia/3ELDYR4T4vuLTyCA4UVOiKA=
 github.com/bobg/seqs v1.2.0/go.mod h1:icgB+vXIoU6s675tLYVAgcUYry1PkYwgEKvzOuFemOk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/parallel/parallel.go
+++ b/parallel/parallel.go
@@ -36,7 +36,7 @@ func (e Error) Unwrap() error {
 //
 // The resulting slice has length n.
 // The value at position i comes from worker i.
-func Values[T any, F ~func(context.Context, int) (T, error)](ctx context.Context, n int, f F) ([]T, error) {
+func Values[T any](ctx context.Context, n int, f func(context.Context, int) (T, error)) ([]T, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	result := make([]T, n)
 
@@ -74,7 +74,7 @@ func Values[T any, F ~func(context.Context, int) (T, error)](ctx context.Context
 // but not before the iterator has been fully consumed.
 // The error (if there is one) is of type [Error],
 // whose N field indicates which worker failed.
-func Producers[T any, F ~func(context.Context, int, func(T) error) error](ctx context.Context, n int, f F) (iter.Seq[T], *error) {
+func Producers[T any](ctx context.Context, n int, f func(context.Context, int, func(T) error) error) (iter.Seq[T], *error) {
 	ch := make(chan T)
 	g, innerCtx := errgroup.WithContext(ctx)
 
@@ -126,7 +126,7 @@ func Producers[T any, F ~func(context.Context, int, func(T) error) error](ctx co
 // After any error, the value-sending callback will return an error.
 // (Not the original error, however.
 // For that, the caller should still invoke the close callback.)
-func Consumers[T any, F ~func(context.Context, int, T) error](ctx context.Context, n int, f F) (func(T) error, func() error) {
+func Consumers[T any](ctx context.Context, n int, f func(context.Context, int, T) error) (func(T) error, func() error) {
 	ch := make(chan T, n)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -175,7 +175,7 @@ func Consumers[T any, F ~func(context.Context, int, T) error](ctx context.Contex
 //
 // Each call of the callback is synchronous.
 // Any desired concurrency is the responsibility of the caller.
-func Pool[T, U any, F ~func(T) (U, error)](n int, f F) func(T) (U, error) {
+func Pool[T, U any](n int, f func(T) (U, error)) func(T) (U, error) {
 	var (
 		running int
 		mu      sync.Mutex


### PR DESCRIPTION
Forgot this before creating the v4.0.0 release (which is now retracted in favor of v4.1.0): removing the `~func(...)` type parameters from the functions in `parallel`.